### PR TITLE
Fix CI: build before test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Test
-        run: npm run test
-
       - name: Build
         run: npm run build
+
+      - name: Test
+        run: npm run test


### PR DESCRIPTION
## Summary
- Integration tests need `dist/cli.js` but CI was running tests before build
- Swapped the Build and Test step order in the CI workflow

## Test plan
- [x] All 127 tests pass locally after build
- [ ] CI should go green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)