### PR TITLE
Fix biome formatting in add.ts and output.test.ts

### DIFF
--- a/src/commands/tools/add.ts
+++ b/src/commands/tools/add.ts
@@ -120,8 +120,7 @@ async function addBuiltInTool(
   const fallbackName = selectedModel.id.startsWith(`${toolId}-`)
     ? selectedModel.id
     : `${toolId}-${selectedModel.id}`;
-  const defaultName =
-    nameOverride ?? selectedModel.compoundId ?? fallbackName;
+  const defaultName = nameOverride ?? selectedModel.compoundId ?? fallbackName;
   let name = nameOverride ?? (await promptInput('Tool name:', defaultName));
 
   if (!SAFE_ID_RE.test(name)) {

--- a/tests/unit/output.test.ts
+++ b/tests/unit/output.test.ts
@@ -47,7 +47,9 @@ describe('formatTestResults', () => {
         command: '/bin/claude -p --output-format text --model opus',
       },
     ]);
-    expect(output).toContain('$ /bin/claude -p --output-format text --model opus');
+    expect(output).toContain(
+      '$ /bin/claude -p --output-format text --model opus',
+    );
   });
 
   it('omits command line when command is undefined', () => {


### PR DESCRIPTION
## Summary
- Fix line-length formatting in `src/commands/tools/add.ts` (collapse two-line assignment to one)
- Fix line-length formatting in `tests/unit/output.test.ts` (wrap long `toContain` call)

## Test plan
- [x] `npx biome check` passes on both files
- [x] All 248 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)