### PR TITLE
Fix biome formatting in doctor.ts

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -181,8 +181,7 @@ export function registerDoctorCommand(program: Command): void {
         join(home, '.local', 'bin', 'counselors'),
         join(home, 'bin', 'counselors'),
       ];
-      const hasStandalone =
-        home && standalonePaths.some((p) => existsSync(p));
+      const hasStandalone = home && standalonePaths.some((p) => existsSync(p));
       if (hasStandalone) sources.push('standalone');
       if (sources.length > 1) {
         checks.push({


### PR DESCRIPTION
## Summary
- Collapse two-line `hasStandalone` assignment to one line to satisfy biome formatter

## Test plan
- [x] `npx biome check` passes
- [x] All tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)