### PR TITLE
fix(executor): pass GH_TOKEN and GITHUB_TOKEN to subprocesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Codex also found 2 bugs all agents acknowledged: dedup by name drops valid sugge
 
 ## Security
 
-- **Environment allowlisting**: Child processes only receive allowlisted environment variables (PATH, HOME, API keys, proxy settings, etc.) — no full `process.env` leak.
+- **Environment allowlisting**: Child processes only receive allowlisted environment variables (PATH, HOME, API keys, GH_TOKEN, proxy settings, etc.) — no full `process.env` leak.
 - **Atomic config writes**: Config files are written atomically via temp+rename with `0o600` permissions.
 - **Tool name validation**: Tool IDs are validated against `[a-zA-Z0-9._-]` to prevent path traversal.
 - **No shell execution**: All child processes use `execFile`/`spawn` without `shell: true`.

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -100,6 +100,9 @@ const ENV_ALLOWLIST = [
   'GOOGLE_CLOUD_PROJECT',
   'GOOGLE_CLOUD_LOCATION',
   'AMP_API_KEY',
+  // GitHub CLI auth
+  'GH_TOKEN',
+  'GITHUB_TOKEN',
   // Proxy
   'HTTP_PROXY',
   'HTTPS_PROXY',

--- a/tests/unit/executor.test.ts
+++ b/tests/unit/executor.test.ts
@@ -365,6 +365,29 @@ describe('execute', () => {
     }
   });
 
+  it('passes GH_TOKEN and GITHUB_TOKEN through to child processes', async () => {
+    process.env.GH_TOKEN = 'test-gh-token';
+    process.env.GITHUB_TOKEN = 'test-github-token';
+    try {
+      const result = await execute(
+        {
+          cmd: 'node',
+          args: [
+            '-e',
+            'process.stdout.write([process.env.GH_TOKEN, process.env.GITHUB_TOKEN].join(","))',
+          ],
+          cwd: process.cwd(),
+        },
+        5000,
+      );
+
+      expect(result.stdout).toBe('test-gh-token,test-github-token');
+    } finally {
+      delete process.env.GH_TOKEN;
+      delete process.env.GITHUB_TOKEN;
+    }
+  });
+
   it('blocks NODE_OPTIONS from reaching child processes', async () => {
     process.env.NODE_OPTIONS = '--max-old-space-size=4096';
     try {


### PR DESCRIPTION
## Summary

- Add `GH_TOKEN` and `GITHUB_TOKEN` to the subprocess environment variable allowlist in `src/core/executor.ts`
- Add test verifying both tokens pass through to child processes
- Update README security section to mention `GH_TOKEN`

## Problem

Commands like `counselors run "review PR #373 (including the inline comments)"` fail because the AI subprocesses need `gh` CLI access to fetch PR data, but `GH_TOKEN`/`GITHUB_TOKEN` are not on the env allowlist. The `gh` CLI errors with "token is invalid" since it receives no authentication token.

## Precedent

Follows the same pattern as #13, which added `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` to the allowlist for Vertex AI auth.

## Test plan

- [x] Existing tests pass (22/22)
- [x] New test verifies `GH_TOKEN` and `GITHUB_TOKEN` reach child processes
- [ ] Manual: `counselors run "run gh auth status"` succeeds with `GH_TOKEN` set