### PR TITLE
Replace Gemini 3 Pro with Gemini 3.1 Pro

### DIFF
--- a/src/adapters/gemini.ts
+++ b/src/adapters/gemini.ts
@@ -9,14 +9,9 @@ export class GeminiAdapter extends BaseAdapter {
   readOnly = { level: 'enforced' as const }; 
   models = [
     {
-      id: 'gemini-3-pro',
-      name: 'Gemini 3 Pro — latest',
-      recommended: true,
-      extraFlags: ['-m', 'gemini-3-pro-preview'],
-    },
-    {
       id: 'gemini-3.1-pro',
-      name: 'Gemini 3.1 Pro',
+      name: 'Gemini 3.1 Pro — latest',
+      recommended: true,
       extraFlags: ['-m', 'gemini-3.1-pro-preview'],
     },
     {

--- a/src/adapters/gemini.ts
+++ b/src/adapters/gemini.ts
@@ -6,13 +6,18 @@ export class GeminiAdapter extends BaseAdapter {
   displayName = 'Gemini CLI';
   commands = ['gemini'];
   installUrl = 'https://github.com/google-gemini/gemini-cli';
-  readOnly = { level: 'enforced' as const };
+  readOnly = { level: 'enforced' as const }; 
   models = [
     {
       id: 'gemini-3-pro',
       name: 'Gemini 3 Pro — latest',
       recommended: true,
       extraFlags: ['-m', 'gemini-3-pro-preview'],
+    },
+    {
+      id: 'gemini-3.1-pro',
+      name: 'Gemini 3.1 Pro',
+      extraFlags: ['-m', 'gemini-3.1-pro-preview'],
     },
     {
       id: 'gemini-2.5-pro',


### PR DESCRIPTION
Google has shipped Gemini 3.1 Pro, which supersedes 3 Pro. This swaps out
`gemini-3-pro-preview` for `gemini-3.1-pro-preview` as the recommended
model in the Gemini adapter.

References:
- https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-1-pro/
- https://cloud.google.com/blog/products/ai-machine-learning/gemini-3-1-pro-on-gemini-cli-gemini-enterprise-and-vertex-ai
