### PR TITLE
fix: Windows path separator in loop test regex

### DIFF
--- a/src/ui/agent-reporter.ts
+++ b/src/ui/agent-reporter.ts
@@ -108,7 +108,7 @@ export class AgentReporter implements Reporter {
   roundStarted(round: number, totalRounds: number | null): void {
     if (round > 1) {
       const elapsed = Date.now() - this.executionStart;
-      let timing = formatDuration(elapsed) + ' elapsed';
+      let timing = `${formatDuration(elapsed)} elapsed`;
       if (this.durationMs) {
         const remaining = Math.max(0, this.durationMs - elapsed);
         timing += ` \u00b7 ~${formatDuration(remaining)} remaining`;

--- a/src/ui/terminal-reporter.ts
+++ b/src/ui/terminal-reporter.ts
@@ -137,7 +137,7 @@ export class TerminalReporter implements Reporter {
       this.lineCount = 0;
 
       const elapsed = Date.now() - this.executionStart;
-      let timing = formatDuration(elapsed) + ' elapsed';
+      let timing = `${formatDuration(elapsed)} elapsed`;
       if (this.durationMs) {
         const remaining = Math.max(0, this.durationMs - elapsed);
         timing += ` \u00b7 ~${formatDuration(remaining)} remaining`;

--- a/tests/unit/loop.test.ts
+++ b/tests/unit/loop.test.ts
@@ -139,7 +139,7 @@ describe('runLoop', () => {
     expect(finalPrompt).toContain(
       'Only the most recent 8 outputs are included',
     );
-    const refCount = (finalPrompt.match(/@.*round-\d+\/claude\.md/g) ?? [])
+    const refCount = (finalPrompt.match(/@.*round-\d+[/\\]claude\.md/g) ?? [])
       .length;
     expect(refCount).toBe(8);
   });


### PR DESCRIPTION
## Summary
- The loop test "caps prior-round references to control prompt size" was failing on all Windows CI matrix entries (Node 20, 22, 24)
- Root cause: the test regex `/@.*round-\d+\/claude\.md/g` only matched forward slashes, but `path.join()` produces backslashes on Windows
- Updated the regex to `/@.*round-\d+[/\\]claude\.md/g` to match both path separators
- Also fixed two pre-existing lint warnings (string concatenation -> template literals) in `agent-reporter.ts` and `terminal-reporter.ts`

## Test plan
- [x] All 443 tests pass locally
- [x] Lint passes clean (0 errors, 0 infos)
- [x] Typecheck passes
- [x] Build succeeds
- [ ] CI passes on all matrix entries (ubuntu + windows, Node 20/22/24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)