### PR TITLE
fix: clean up orphaned child process trees

### DIFF
--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -16,6 +16,7 @@ import { debug } from '../ui/logger.js';
 
 const MAX_OUTPUT_BYTES = 10 * 1024 * 1024; // 10MB
 const WINDOWS_TASKKILL_TIMEOUT_MS = 1500;
+const SIGINT_EXIT_DELAY_MS = 2000;
 
 const activeChildren = new Set<ChildProcess>();
 
@@ -59,13 +60,61 @@ function killProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
 }
 
 let sigintExitTimer: ReturnType<typeof setTimeout> | null = null;
+let sigintKillTimer: ReturnType<typeof setTimeout> | null = null;
+let sigintCount = 0;
+
+function terminateActiveChildren(signal: NodeJS.Signals): void {
+  for (const child of activeChildren) {
+    killProcessGroup(child, signal);
+  }
+}
+
+function scheduleSigintEscalation(): void {
+  if (sigintKillTimer) return;
+  sigintKillTimer = setTimeout(() => {
+    sigintKillTimer = null;
+    terminateActiveChildren('SIGKILL');
+  }, KILL_GRACE_PERIOD);
+  sigintKillTimer.unref();
+}
+
+function scheduleSigintExit(): void {
+  if (sigintExitTimer) clearTimeout(sigintExitTimer);
+  sigintExitTimer = setTimeout(() => {
+    terminateActiveChildren('SIGKILL');
+    process.exit(1);
+  }, SIGINT_EXIT_DELAY_MS);
+}
 
 process.on('SIGINT', () => {
-  for (const child of activeChildren) {
-    killProcessGroup(child, 'SIGTERM');
+  sigintCount++;
+  if (sigintCount > 1) {
+    terminateActiveChildren('SIGKILL');
+    process.exit(1);
+    return;
   }
-  // Give children a moment to exit, then force-exit
-  sigintExitTimer = setTimeout(() => process.exit(1), 2000);
+
+  terminateActiveChildren('SIGTERM');
+  scheduleSigintEscalation();
+  // Give children a moment to exit, then force-exit.
+  // Loop mode can clear this timer to finish writing manifests.
+  scheduleSigintExit();
+});
+
+process.on('SIGTERM', () => {
+  terminateActiveChildren('SIGTERM');
+  scheduleSigintEscalation();
+  scheduleSigintExit();
+});
+
+process.on('SIGHUP', () => {
+  terminateActiveChildren('SIGTERM');
+  scheduleSigintEscalation();
+  scheduleSigintExit();
+});
+
+process.on('exit', () => {
+  terminateActiveChildren('SIGKILL');
 });
 
 /** Clear the scheduled auto-exit so the loop can finish writing manifests. */
@@ -282,6 +331,9 @@ export function execute(
       processExited = true;
       clearTimeout(timer);
       if (killTimer) clearTimeout(killTimer);
+      // If the primary child exits but leaves descendants alive in the same
+      // process group (common with some CLIs), terminate the group now.
+      killProcessGroup(child, 'SIGKILL');
       activeChildren.delete(child);
       resolve({
         exitCode: code ?? 1,

--- a/tests/unit/executor.test.ts
+++ b/tests/unit/executor.test.ts
@@ -599,4 +599,48 @@ setInterval(() => {}, 1000);
       rmSync(markerPath, { force: true });
     }
   });
+
+  it('does not leave grandchildren running after normal child exit', async () => {
+    if (process.platform === 'win32') return;
+
+    const markerPath = join(
+      tmpdir(),
+      `counselors-normal-orphan-${process.pid}-${Date.now()}.txt`,
+    );
+
+    const grandchildScript = `
+const fs = require('node:fs');
+setTimeout(() => {
+  fs.writeFileSync(${JSON.stringify(markerPath)}, 'orphan');
+  process.exit(0);
+}, 1200);
+setInterval(() => {}, 1000);
+`;
+
+    const parentScript = `
+const { spawn } = require('node:child_process');
+spawn(process.execPath, ['-e', ${JSON.stringify(grandchildScript)}], {
+  stdio: 'ignore',
+});
+process.exit(0);
+`;
+
+    try {
+      const result = await execute(
+        {
+          cmd: 'node',
+          args: ['-e', parentScript],
+          cwd: process.cwd(),
+        },
+        5_000,
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      await new Promise((resolve) => setTimeout(resolve, 1_800));
+      expect(existsSync(markerPath)).toBe(false);
+    } finally {
+      rmSync(markerPath, { force: true });
+    }
+  });
 });


### PR DESCRIPTION
- Fix orphaned child-process trees by improving shutdown cleanup in `execute`.
- Add centralized child termination helpers and signal handling for `SIGINT`, `SIGTERM`, and `SIGHUP`.
- Add final safety cleanup on process `exit` to kill any remaining active child process groups.
- Kill lingering descendants when a child closes, preventing subprocesses from surviving normal completion.
- Add a regression test proving normal child exit does not leave grandchildren running.

I noticed that sometimes some orphaned amp cli processed would be kept around after the counselors were already done. This fixes that. Feel free to nuke my code. I whipped this up with codex 5.3. The test i added is a reproduction of this bug so that might be useful.