### PR TITLE
Support delays between rounds

### DIFF
--- a/src/commands/loop.ts
+++ b/src/commands/loop.ts
@@ -447,6 +447,12 @@ export function registerLoopCommand(program: Command): void {
             if (event.event === 'completed')
               reporter.toolCompleted(event.toolId, event.report!);
           },
+          onRoundDelay: (nextRound, delayMs) => {
+            reporter.roundDelayStarted(nextRound, delayMs);
+          },
+          onRoundDelayEnd: () => {
+            reporter.roundDelayEnded();
+          },
           onConvergence: (round, ratio) => {
             reporter.convergenceDetected(round, ratio, convergenceThreshold);
           },

--- a/src/commands/loop.ts
+++ b/src/commands/loop.ts
@@ -11,7 +11,7 @@ import { synthesizeFinal } from '../core/synthesis.js';
 import { getPresetNames, resolvePreset } from '../presets/index.js';
 import type { PresetDefinition } from '../presets/types.js';
 import type { RunManifest } from '../types.js';
-import { error, info } from '../ui/logger.js';
+import { error, info, warn } from '../ui/logger.js';
 import { formatDryRun } from '../ui/output.js';
 import { createReporter } from '../ui/reporter.js';
 import {
@@ -69,6 +69,7 @@ export function registerLoopCommand(program: Command): void {
       'Word count ratio for early stop',
       '0.3',
     )
+    .option('--round-delay <time>', 'Delay between rounds (e.g. "30s", "5m")')
     .option('--dry-run', 'Show what would be dispatched without running')
     .option('--json', 'Output manifest as JSON')
     .option('-o, --output-dir <dir>', 'Base output directory');
@@ -89,6 +90,7 @@ export function registerLoopCommand(program: Command): void {
         discoveryTool?: string;
         inlineEnhancement?: boolean;
         convergenceThreshold?: string;
+        roundDelay?: string;
         dryRun?: boolean;
         json?: boolean;
         outputDir?: string;
@@ -160,6 +162,28 @@ export function registerLoopCommand(program: Command): void {
         error('--convergence-threshold must be a number between 0 and 1.');
         process.exitCode = 1;
         return;
+      }
+
+      // Parse round delay
+      let roundDelayMs: number | undefined;
+      if (opts.roundDelay) {
+        try {
+          roundDelayMs = parseDurationMs(opts.roundDelay);
+          // Warn about bare numeric values (interpreted as days)
+          if (/^\d+(\.\d+)?$/.test(opts.roundDelay)) {
+            warn(
+              `--round-delay ${opts.roundDelay} interpreted as ${opts.roundDelay} days. Did you mean ${opts.roundDelay}s (seconds) or ${opts.roundDelay}m (minutes)?`,
+            );
+          }
+        } catch (e) {
+          error(
+            e instanceof Error
+              ? e.message
+              : `Invalid --round-delay value "${opts.roundDelay}".`,
+          );
+          process.exitCode = 1;
+          return;
+        }
       }
 
       // Resolve preset
@@ -378,6 +402,9 @@ export function registerLoopCommand(program: Command): void {
           info(`  Preset: ${preset.name}`);
         }
         info(`  Convergence threshold: ${convergenceThreshold}`);
+        if (roundDelayMs) {
+          info(`  Round delay: ${opts.roundDelay}`);
+        }
         return;
       }
 
@@ -410,6 +437,7 @@ export function registerLoopCommand(program: Command): void {
           rounds,
           durationMs,
           convergenceThreshold,
+          roundDelayMs,
           onRoundStart: (round) => {
             reporter.roundStarted(round, totalRoundsLabel);
           },

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -173,6 +173,7 @@ Using \`-f\` skips the discovery/prompt-writing phases and sends the prompt as-i
 - \`--rounds <N>\` — number of rounds (default: 3)
 - \`--duration <time>\` — max wall time (e.g. \`30m\`, \`1h\`); when set without explicit \`--rounds\`, rounds are unlimited
 - \`--convergence-threshold <ratio>\` — early stop when output word count drops below this ratio of the previous round (default: 0.3)
+- \`--round-delay <time>\` — delay between rounds (e.g. \`30s\`, \`5m\`, useful for rate limiting)
 
 ### Mode C: \`loop\` + inline prompt (iterative, no preset, auto-enhanced)
 
@@ -212,6 +213,7 @@ In rounds 2+, counselors automatically augments the prompt with \`@file\` refere
 | \`--rounds <N>\` | Number of rounds (default: 3) |
 | \`--duration <time>\` | Max wall time (\`30m\`, \`1h\`); unlimited rounds when set alone |
 | \`--convergence-threshold <ratio>\` | Early stop ratio (default: 0.3) |
+| \`--round-delay <time>\` | Delay between rounds (\`30s\`, \`5m\`) |
 | \`--discovery-tool <id>\` | Agent for prep phases (default: first tool) |
 | \`--no-inline-enhancement\` | Skip discovery/prompt-writing for inline prompts |
 

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import type { Config, ReadOnlyLevel, RoundManifest } from '../types.js';
+import { warn } from '../ui/logger.js';
 import type { ProgressEvent } from './dispatcher.js';
 import { dispatch } from './dispatcher.js';
 import { clearSigintExit } from './executor.js';
@@ -19,6 +20,8 @@ export interface LoopOptions {
   durationMs?: number;
   /** Word count ratio threshold for early stop (default: 0.3). */
   convergenceThreshold?: number;
+  /** Delay between rounds in milliseconds (default: 0). */
+  roundDelayMs?: number;
   onRoundStart?: (round: number) => void;
   onRoundComplete?: (round: number, manifest: RoundManifest) => void;
   onConvergence?: (round: number, ratio: number) => void;
@@ -37,6 +40,19 @@ function totalWordCount(round: RoundManifest): number {
   return round.tools.reduce((sum, r) => sum + r.wordCount, 0);
 }
 
+/** Returns an awaitable promise with a `.cancel()` method to resolve it early. */
+function cancellableDelay(ms: number): Promise<void> & { cancel: () => void } {
+  let cancel!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    cancel = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+  });
+  return Object.assign(promise, { cancel });
+}
+
 /**
  * Run multiple dispatch rounds, feeding prior round outputs into subsequent rounds.
  */
@@ -51,6 +67,7 @@ export async function runLoop(options: LoopOptions): Promise<LoopResult> {
     rounds: maxRounds,
     durationMs,
     convergenceThreshold = 0.3,
+    roundDelayMs = 0,
     onRoundStart,
     onRoundComplete,
     onConvergence,
@@ -62,6 +79,8 @@ export async function runLoop(options: LoopOptions): Promise<LoopResult> {
   let outcome: LoopResult['outcome'] = 'completed';
   let aborted = false;
 
+  let delayCancel: (() => void) | null = null;
+
   // SIGINT: let the current round finish, then stop the loop.
   // Second SIGINT falls through to the executor's handler which force-exits.
   let sigintCount = 0;
@@ -72,6 +91,9 @@ export async function runLoop(options: LoopOptions): Promise<LoopResult> {
       outcome = 'aborted';
       // Suppress the executor's auto-exit so we can write manifests
       clearSigintExit();
+      if (delayCancel) {
+        delayCancel();
+      }
     }
     // Second SIGINT: re-register original behavior (process will exit via executor handler)
   };
@@ -166,6 +188,26 @@ export async function runLoop(options: LoopOptions): Promise<LoopResult> {
             break;
           }
         }
+      }
+
+      if (roundDelayMs > 0 && round < maxRounds && !aborted) {
+        const remaining =
+          durationMs != null
+            ? durationMs - (Date.now() - startTime)
+            : Infinity;
+        if (remaining <= 0) {
+          outcome = 'aborted';
+          break;
+        }
+
+        const actualDelay = Math.min(roundDelayMs, remaining);
+        warn(
+          `Waiting ${Math.ceil(actualDelay / 1000)}s before round ${round + 1}... (Ctrl+C to stop)`,
+        );
+        const delay = cancellableDelay(actualDelay);
+        delayCancel = delay.cancel;
+        await delay;
+        delayCancel = null;
       }
     }
   } finally {

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
 import type { Config, ReadOnlyLevel, RoundManifest } from '../types.js';
-import { warn } from '../ui/logger.js';
 import type { ProgressEvent } from './dispatcher.js';
 import { dispatch } from './dispatcher.js';
 import { clearSigintExit } from './executor.js';
@@ -25,6 +25,8 @@ export interface LoopOptions {
   onRoundStart?: (round: number) => void;
   onRoundComplete?: (round: number, manifest: RoundManifest) => void;
   onConvergence?: (round: number, ratio: number) => void;
+  onRoundDelay?: (nextRound: number, delayMs: number) => void;
+  onRoundDelayEnd?: () => void;
   onProgress?: (event: ProgressEvent) => void;
 }
 
@@ -38,19 +40,6 @@ const MAX_PRIOR_REPORT_REFS = 8;
 /** Sum word counts across all tool reports in a round. */
 function totalWordCount(round: RoundManifest): number {
   return round.tools.reduce((sum, r) => sum + r.wordCount, 0);
-}
-
-/** Returns an awaitable promise with a `.cancel()` method to resolve it early. */
-function cancellableDelay(ms: number): Promise<void> & { cancel: () => void } {
-  let cancel!: () => void;
-  const promise = new Promise<void>((resolve) => {
-    const timer = setTimeout(resolve, ms);
-    cancel = () => {
-      clearTimeout(timer);
-      resolve();
-    };
-  });
-  return Object.assign(promise, { cancel });
 }
 
 /**
@@ -71,6 +60,8 @@ export async function runLoop(options: LoopOptions): Promise<LoopResult> {
     onRoundStart,
     onRoundComplete,
     onConvergence,
+    onRoundDelay,
+    onRoundDelayEnd,
     onProgress,
   } = options;
 
@@ -79,7 +70,7 @@ export async function runLoop(options: LoopOptions): Promise<LoopResult> {
   let outcome: LoopResult['outcome'] = 'completed';
   let aborted = false;
 
-  let delayCancel: (() => void) | null = null;
+  let delayAbort: AbortController | null = null;
 
   // SIGINT: let the current round finish, then stop the loop.
   // Second SIGINT falls through to the executor's handler which force-exits.
@@ -91,9 +82,7 @@ export async function runLoop(options: LoopOptions): Promise<LoopResult> {
       outcome = 'aborted';
       // Suppress the executor's auto-exit so we can write manifests
       clearSigintExit();
-      if (delayCancel) {
-        delayCancel();
-      }
+      delayAbort?.abort();
     }
     // Second SIGINT: re-register original behavior (process will exit via executor handler)
   };
@@ -201,13 +190,13 @@ export async function runLoop(options: LoopOptions): Promise<LoopResult> {
         }
 
         const actualDelay = Math.min(roundDelayMs, remaining);
-        warn(
-          `Waiting ${Math.ceil(actualDelay / 1000)}s before round ${round + 1}... (Ctrl+C to stop)`,
+        onRoundDelay?.(round + 1, actualDelay);
+        delayAbort = new AbortController();
+        await delay(actualDelay, undefined, { signal: delayAbort.signal }).catch(
+          () => {},
         );
-        const delay = cancellableDelay(actualDelay);
-        delayCancel = delay.cancel;
-        await delay;
-        delayCancel = null;
+        delayAbort = null;
+        onRoundDelayEnd?.();
       }
     }
   } finally {

--- a/src/ui/agent-reporter.ts
+++ b/src/ui/agent-reporter.ts
@@ -31,6 +31,7 @@ export class AgentReporter implements Reporter {
   private heartbeatStart = 0;
   private executionStart = 0;
   private durationMs: number | undefined;
+  private totalRounds: number | null = null;
 
   // ── Preset phases ──
 
@@ -117,6 +118,7 @@ export class AgentReporter implements Reporter {
   // ── Round management ──
 
   roundStarted(round: number, totalRounds: number | null): void {
+    this.totalRounds = totalRounds;
     if (round > 1) {
       const elapsed = Date.now() - this.executionStart;
       let timing = `${formatDuration(elapsed)} elapsed`;
@@ -141,8 +143,12 @@ export class AgentReporter implements Reporter {
   }
 
   roundDelayStarted(nextRound: number, delayMs: number): void {
+    const roundLabel =
+      this.totalRounds != null
+        ? `${nextRound}/${this.totalRounds}`
+        : `${nextRound}`;
     this.stderr(
-      `  \u23f3 Starting round ${nextRound} after ${formatDuration(delayMs)} (Ctrl+C to stop)`,
+      `  Round ${roundLabel}: starting after ${formatDuration(delayMs)} (Ctrl+C to stop)`,
     );
   }
 

--- a/src/ui/agent-reporter.ts
+++ b/src/ui/agent-reporter.ts
@@ -6,8 +6,10 @@ const HEARTBEAT_INTERVAL = 60_000;
 
 function formatDuration(ms: number): string {
   const seconds = Math.floor(ms / 1000);
-  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
   const secs = seconds % 60;
+  if (hours > 0) return `${hours}h ${minutes}m ${secs}s`;
   if (minutes > 0) return `${minutes}m ${secs}s`;
   return `${secs}s`;
 }
@@ -137,6 +139,14 @@ export class AgentReporter implements Reporter {
   roundCompleted(_round: number): void {
     // No-op for agent — tool completion messages already printed
   }
+
+  roundDelayStarted(nextRound: number, delayMs: number): void {
+    this.stderr(
+      `  \u23f3 Starting round ${nextRound} after ${formatDuration(delayMs)} (Ctrl+C to stop)`,
+    );
+  }
+
+  roundDelayEnded(): void {}
 
   convergenceDetected(round: number, ratio: number, threshold: number): void {
     this.stderr(

--- a/src/ui/agent-reporter.ts
+++ b/src/ui/agent-reporter.ts
@@ -143,12 +143,13 @@ export class AgentReporter implements Reporter {
   }
 
   roundDelayStarted(nextRound: number, delayMs: number): void {
+    const delaySecs = Math.ceil(delayMs / 1000);
     const roundLabel =
       this.totalRounds != null
         ? `${nextRound}/${this.totalRounds}`
         : `${nextRound}`;
     this.stderr(
-      `  Round ${roundLabel}: starting after ${formatDuration(delayMs)} (Ctrl+C to stop)`,
+      `  Round ${roundLabel}: starting after ${delaySecs}s (Ctrl+C to stop)`,
     );
   }
 

--- a/src/ui/reporter.ts
+++ b/src/ui/reporter.ts
@@ -24,6 +24,8 @@ export interface Reporter {
   roundStarted(round: number, totalRounds: number | null): void;
   roundCompleted(round: number): void;
   convergenceDetected(round: number, ratio: number, threshold: number): void;
+  roundDelayStarted(nextRound: number, delayMs: number): void;
+  roundDelayEnded(): void;
 
   // ── Final output (stdout) ──
   printSummary(manifest: RunManifest, opts: { json?: boolean }): void;
@@ -42,6 +44,8 @@ export class NullReporter implements Reporter {
   roundStarted(): void {}
   roundCompleted(): void {}
   convergenceDetected(): void {}
+  roundDelayStarted(): void {}
+  roundDelayEnded(): void {}
   printSummary(): void {}
 }
 

--- a/src/ui/terminal-reporter.ts
+++ b/src/ui/terminal-reporter.ts
@@ -14,8 +14,10 @@ const RESET = '\x1b[0m';
 
 function formatDuration(ms: number): string {
   const seconds = Math.floor(ms / 1000);
-  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
   const secs = seconds % 60;
+  if (hours > 0) return `${hours}h ${minutes}m ${secs}s`;
   if (minutes > 0) return `${minutes}m ${secs}s`;
   return `${secs}s`;
 }
@@ -51,6 +53,8 @@ export class TerminalReporter implements Reporter {
   private executionActive = false;
   private executionStart = 0;
   private durationMs: number | undefined;
+  private delayEndTime: number | undefined;
+  private delayNextRound: number | undefined;
   private phaseSpinner: ReturnType<typeof setInterval> | null = null;
   private phaseFrame = 0;
   private phaseText = '';
@@ -166,6 +170,16 @@ export class TerminalReporter implements Reporter {
     // No-op — toolCompleted already updated state; render loop shows it
   }
 
+  roundDelayStarted(nextRound: number, delayMs: number): void {
+    this.delayEndTime = Date.now() + delayMs;
+    this.delayNextRound = nextRound;
+  }
+
+  roundDelayEnded(): void {
+    this.delayEndTime = undefined;
+    this.delayNextRound = undefined;
+  }
+
   convergenceDetected(round: number, ratio: number, threshold: number): void {
     this.clearStatus();
     this.stderr(
@@ -266,6 +280,13 @@ export class TerminalReporter implements Reporter {
       }
     }
 
+    if (this.delayEndTime != null) {
+      const remaining = Math.max(0, this.delayEndTime - Date.now());
+      lines.push(
+        `  \u23f3 Starting round ${this.delayNextRound} after ${formatDuration(remaining)} (Ctrl+C to stop)`,
+      );
+    }
+
     // Move cursor up to overwrite previous output
     if (this.lineCount > 0) {
       process.stderr.write(`\x1b[${this.lineCount}A`);
@@ -273,6 +294,15 @@ export class TerminalReporter implements Reporter {
 
     for (const line of lines) {
       process.stderr.write(`\x1b[K${line}\n`);
+    }
+
+    // Clear stale lines if line count decreased
+    const staleCount = this.lineCount - lines.length;
+    if (staleCount > 0) {
+      for (let i = 0; i < staleCount; i++) {
+        process.stderr.write('\x1b[K\n');
+      }
+      process.stderr.write(`\x1b[${staleCount}A`);
     }
 
     this.lineCount = lines.length;

--- a/src/ui/terminal-reporter.ts
+++ b/src/ui/terminal-reporter.ts
@@ -250,16 +250,7 @@ export class TerminalReporter implements Reporter {
 
   private render(): void {
     const lines: string[] = [];
-    if (this.delayEndTime != null) {
-      const remaining = Math.max(0, this.delayEndTime - Date.now());
-      const roundLabel =
-        this.totalRounds != null
-          ? `${this.delayNextRound}/${this.totalRounds}`
-          : `${this.delayNextRound}`;
-      lines.push(
-        `  Round ${roundLabel}: starting after ${formatDuration(remaining)} (Ctrl+C to stop)`,
-      );
-    } else if (this.currentRound != null) {
+    if (this.currentRound != null) {
       const roundLabel =
         this.totalRounds != null
           ? `${this.currentRound}/${this.totalRounds}`
@@ -287,6 +278,17 @@ export class TerminalReporter implements Reporter {
       ) {
         lines.push(`    ${RED}\u2514 see ${tool.report.stderrFile}${RESET}`);
       }
+    }
+
+    if (this.delayEndTime != null) {
+      const remaining = Math.max(0, this.delayEndTime - Date.now());
+      const roundLabel =
+        this.totalRounds != null
+          ? `${this.delayNextRound}/${this.totalRounds}`
+          : `${this.delayNextRound}`;
+      lines.push(
+        `  Round ${roundLabel}: starting after ${formatDuration(remaining)} (Ctrl+C to stop)`,
+      );
     }
 
     // Move cursor up to overwrite previous output

--- a/src/ui/terminal-reporter.ts
+++ b/src/ui/terminal-reporter.ts
@@ -282,12 +282,13 @@ export class TerminalReporter implements Reporter {
 
     if (this.delayEndTime != null) {
       const remaining = Math.max(0, this.delayEndTime - Date.now());
+      const remainingSecs = Math.ceil(remaining / 1000);
       const roundLabel =
         this.totalRounds != null
           ? `${this.delayNextRound}/${this.totalRounds}`
           : `${this.delayNextRound}`;
       lines.push(
-        `  Round ${roundLabel}: starting after ${formatDuration(remaining)} (Ctrl+C to stop)`,
+        `  Round ${roundLabel}: starting after ${remainingSecs}s (Ctrl+C to stop)`,
       );
     }
 

--- a/src/ui/terminal-reporter.ts
+++ b/src/ui/terminal-reporter.ts
@@ -140,13 +140,11 @@ export class TerminalReporter implements Reporter {
   // ── Round management ──
 
   roundStarted(round: number, totalRounds: number | null): void {
-    this.currentRound = round;
     this.totalRounds = totalRounds;
 
     // On rounds after the first, commit the previous round's final table
     // and show timing info
     if (round > 1) {
-      // Flush current render so it stays on screen
       this.render();
       this.lineCount = 0;
 
@@ -159,6 +157,8 @@ export class TerminalReporter implements Reporter {
       timing += ` \u00b7 Ctrl+C to stop`;
       this.stderr(`  ${DIM}${timing}${RESET}`);
     }
+
+    this.currentRound = round;
 
     // Reset tool states for the new round
     for (const [id] of this.tools) {

--- a/src/ui/terminal-reporter.ts
+++ b/src/ui/terminal-reporter.ts
@@ -250,7 +250,16 @@ export class TerminalReporter implements Reporter {
 
   private render(): void {
     const lines: string[] = [];
-    if (this.currentRound != null) {
+    if (this.delayEndTime != null) {
+      const remaining = Math.max(0, this.delayEndTime - Date.now());
+      const roundLabel =
+        this.totalRounds != null
+          ? `${this.delayNextRound}/${this.totalRounds}`
+          : `${this.delayNextRound}`;
+      lines.push(
+        `  Round ${roundLabel}: starting after ${formatDuration(remaining)} (Ctrl+C to stop)`,
+      );
+    } else if (this.currentRound != null) {
       const roundLabel =
         this.totalRounds != null
           ? `${this.currentRound}/${this.totalRounds}`
@@ -278,13 +287,6 @@ export class TerminalReporter implements Reporter {
       ) {
         lines.push(`    ${RED}\u2514 see ${tool.report.stderrFile}${RESET}`);
       }
-    }
-
-    if (this.delayEndTime != null) {
-      const remaining = Math.max(0, this.delayEndTime - Date.now());
-      lines.push(
-        `  \u23f3 Starting round ${this.delayNextRound} after ${formatDuration(remaining)} (Ctrl+C to stop)`,
-      );
     }
 
     // Move cursor up to overwrite previous output

--- a/tests/unit/agent-reporter.test.ts
+++ b/tests/unit/agent-reporter.test.ts
@@ -256,6 +256,51 @@ describe('AgentReporter rounds', () => {
   });
 });
 
+describe('AgentReporter round delay', () => {
+  it('prints delay message with round label and duration', async () => {
+    const r = await createReporter();
+    r.executionStarted('/tmp/output', ['claude']);
+    r.roundStarted(1, 3);
+    stderrOutput = '';
+
+    r.roundDelayStarted(2, 30_000);
+    expect(stderrOutput).toContain('Round 2/3: starting after 30s');
+    expect(stderrOutput).toContain('Ctrl+C to stop');
+    r.executionFinished();
+  });
+
+  it('uses Math.ceil so sub-second values never show 0s', async () => {
+    const r = await createReporter();
+    r.executionStarted('/tmp/output', ['claude']);
+    r.roundStarted(1, 3);
+    stderrOutput = '';
+
+    r.roundDelayStarted(2, 500);
+    expect(stderrOutput).toContain('1s');
+    expect(stderrOutput).not.toContain('0s');
+    r.executionFinished();
+  });
+
+  it('renders round label without total when totalRounds is null', async () => {
+    const r = await createReporter();
+    r.executionStarted('/tmp/output', ['claude']);
+    r.roundStarted(1, null);
+    stderrOutput = '';
+
+    r.roundDelayStarted(2, 10_000);
+    expect(stderrOutput).toContain('Round 2: starting after');
+    expect(stderrOutput).not.toContain('Round 2/');
+    r.executionFinished();
+  });
+
+  it('roundDelayEnded does not throw', async () => {
+    const r = await createReporter();
+    r.executionStarted('/tmp/output', ['claude']);
+    expect(() => r.roundDelayEnded()).not.toThrow();
+    r.executionFinished();
+  });
+});
+
 describe('AgentReporter heartbeat', () => {
   afterEach(() => {
     vi.clearAllTimers();

--- a/tests/unit/loop-command.test.ts
+++ b/tests/unit/loop-command.test.ts
@@ -14,6 +14,7 @@ const mockSynthesizeFinal = vi.fn();
 const mockSafeWriteFile = vi.fn();
 const mockCreateReporter = vi.fn();
 const mockInfo = vi.fn();
+const mockWarn = vi.fn();
 const mockError = vi.fn();
 
 vi.mock('../../src/commands/_run-shared.js', () => ({
@@ -53,6 +54,7 @@ vi.mock('../../src/ui/reporter.js', () => ({
 
 vi.mock('../../src/ui/logger.js', () => ({
   info: (...args: unknown[]) => mockInfo(...args),
+  warn: (...args: unknown[]) => mockWarn(...args),
   error: (...args: unknown[]) => mockError(...args),
 }));
 
@@ -244,5 +246,39 @@ describe('loop command prompt preparation', () => {
     const promptUsed = mockCreateOutputDir.mock.calls[0]?.[2] as string;
     expect(promptUsed).toContain('inline base');
     expect(promptUsed).toContain('## General Guidelines');
+  });
+});
+
+describe('loop command round-delay option', () => {
+  function setupHarness() {
+    const harness = createProgramHarness();
+    registerLoopCommand(harness.program as any);
+    mockResolvePrompt.mockResolvedValue({
+      promptContent: 'test prompt',
+      promptSource: 'file',
+      slug: 'test-slug',
+    });
+    return harness;
+  }
+
+  it('parses round-delay and passes roundDelayMs to runLoop', async () => {
+    const harness = setupHarness();
+    await harness.run(undefined, { file: 'prompt.md', roundDelay: '30s' });
+    expect(mockRunLoop.mock.calls[0]?.[0].roundDelayMs).toBe(30000);
+  });
+
+  it('errors on invalid round-delay format', async () => {
+    const harness = setupHarness();
+    await harness.run(undefined, { file: 'prompt.md', roundDelay: 'invalid' });
+    expect(process.exitCode).toBe(1);
+    expect(mockError).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid duration'),
+    );
+  });
+
+  it('warns when bare numeric value is passed (interpreted as days)', async () => {
+    const harness = setupHarness();
+    await harness.run(undefined, { file: 'prompt.md', roundDelay: '5' });
+    expect(mockWarn).toHaveBeenCalledWith(expect.stringContaining('5 days'));
   });
 });

--- a/tests/unit/loop-command.test.ts
+++ b/tests/unit/loop-command.test.ts
@@ -122,6 +122,8 @@ const reporter = {
   roundStarted: vi.fn(),
   roundCompleted: vi.fn(),
   convergenceDetected: vi.fn(),
+  roundDelayStarted: vi.fn(),
+  roundDelayEnded: vi.fn(),
   printSummary: vi.fn(),
 };
 

--- a/tests/unit/loop.test.ts
+++ b/tests/unit/loop.test.ts
@@ -228,4 +228,35 @@ describe('runLoop', () => {
       expect(result.outcome).toBe('completed');
     });
   });
+
+  describe('round delay', () => {
+    it('delays between rounds but not after the last', async () => {
+      const startTime = Date.now();
+      const result = await runLoop(
+        baseOptions({ rounds: 3, roundDelayMs: 50 }),
+      );
+      const elapsed = Date.now() - startTime;
+
+      expect(result.rounds).toHaveLength(3);
+      expect(result.outcome).toBe('completed');
+      // 2 inter-round delays × 50ms; upper bound proves no extra delay after last round
+      expect(elapsed).toBeGreaterThanOrEqual(80);
+      expect(elapsed).toBeLessThan(200);
+    });
+
+    it('bounds delay by remaining duration', async () => {
+      const startTime = Date.now();
+      // Mock dispatch is ~instant. After round 1, remaining ≈ 100ms.
+      // Delay = min(5000, ~100) ≈ 100ms. Then duration expires before round 2.
+      const result = await runLoop(
+        baseOptions({ rounds: 5, durationMs: 100, roundDelayMs: 5000 }),
+      );
+      const elapsed = Date.now() - startTime;
+
+      expect(result.rounds).toHaveLength(1);
+      expect(result.outcome).toBe('aborted');
+      // Bounded to ~100ms, not 5s
+      expect(elapsed).toBeLessThan(300);
+    });
+  });
 });

--- a/tests/unit/terminal-reporter.test.ts
+++ b/tests/unit/terminal-reporter.test.ts
@@ -258,6 +258,75 @@ describe('TerminalReporter rounds', () => {
   });
 });
 
+describe('TerminalReporter round delay', () => {
+  it('renders countdown line during delay', async () => {
+    vi.useFakeTimers();
+    const r = await createReporter();
+    r.executionStarted('/tmp/output', ['claude']);
+    r.roundStarted(1, 3);
+    r.toolStarted('claude');
+    r.toolCompleted('claude', makeReport({ toolId: 'claude' }));
+
+    r.roundDelayStarted(2, 30_000);
+    vi.advanceTimersByTime(200);
+    expect(stderrOutput).toContain('Round 2/3: starting after');
+    expect(stderrOutput).toContain('Ctrl+C to stop');
+    r.roundDelayEnded();
+    r.executionFinished();
+  });
+
+  it('clears countdown line after roundDelayEnded', async () => {
+    vi.useFakeTimers();
+    const r = await createReporter();
+    r.executionStarted('/tmp/output', ['claude']);
+    r.roundStarted(1, 3);
+
+    r.roundDelayStarted(2, 10_000);
+    vi.advanceTimersByTime(200);
+    expect(stderrOutput).toContain('Round 2/3: starting after');
+
+    r.roundDelayEnded();
+    stderrOutput = '';
+    vi.advanceTimersByTime(200);
+    expect(stderrOutput).not.toContain('starting after');
+    r.executionFinished();
+  });
+
+  it('uses Math.ceil so countdown never shows 0s while waiting', async () => {
+    vi.useFakeTimers();
+    const r = await createReporter();
+    r.executionStarted('/tmp/output', ['claude']);
+    r.roundStarted(1, null);
+
+    r.roundDelayStarted(2, 1500);
+    // At t=0, 1500ms remaining → ceil → 2s
+    expect(stderrOutput).not.toContain('0s');
+
+    vi.advanceTimersByTime(800);
+    // At t=800, 700ms remaining → ceil → 1s
+    stderrOutput = '';
+    vi.advanceTimersByTime(200);
+    expect(stderrOutput).toContain('1s');
+    expect(stderrOutput).not.toContain('0s');
+    r.roundDelayEnded();
+    r.executionFinished();
+  });
+
+  it('renders round label without total when totalRounds is null', async () => {
+    vi.useFakeTimers();
+    const r = await createReporter();
+    r.executionStarted('/tmp/output', ['claude']);
+    r.roundStarted(1, null);
+
+    r.roundDelayStarted(2, 5000);
+    vi.advanceTimersByTime(200);
+    expect(stderrOutput).toContain('Round 2: starting after');
+    expect(stderrOutput).not.toContain('Round 2/');
+    r.roundDelayEnded();
+    r.executionFinished();
+  });
+});
+
 describe('TerminalReporter printSummary', () => {
   it('writes to stdout', async () => {
     const r = await createReporter();


### PR DESCRIPTION
Counselors is the ideal tool to run before going to sleep.
This PR adds delay between iterations of the loop, which could be helpful for avoiding rate limiting.