### PR TITLE
fix: Add GPT-5.4 model variants to Codex adapter

### DIFF
--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -10,10 +10,33 @@ export class CodexAdapter extends BaseAdapter {
   readOnly = { level: 'enforced' as const };
   models = [
     {
+      id: 'gpt-5.4',
+      compoundId: 'codex-5.4-high',
+      name: 'GPT-5.4 — high reasoning',
+      recommended: true,
+      extraFlags: ['-m', 'gpt-5.4', '-c', 'model_reasoning_effort=high'],
+    },
+    {
+      id: 'gpt-5.4',
+      compoundId: 'codex-5.4-xhigh',
+      name: 'GPT-5.4 — xhigh reasoning',
+      extraFlags: ['-m', 'gpt-5.4', '-c', 'model_reasoning_effort=xhigh'],
+    },
+    {
+      id: 'gpt-5.4',
+      compoundId: 'codex-5.4-medium',
+      name: 'GPT-5.4 — medium reasoning',
+      extraFlags: [
+        '-m',
+        'gpt-5.4',
+        '-c',
+        'model_reasoning_effort=medium',
+      ],
+    },
+    {
       id: 'gpt-5.3-codex',
       compoundId: 'codex-5.3-high',
       name: 'GPT-5.3 Codex — high reasoning',
-      recommended: true,
       extraFlags: ['-m', 'gpt-5.3-codex', '-c', 'model_reasoning_effort=high'],
     },
     {


### PR DESCRIPTION
## Summary
- `gpt-5.4-codex` doesn't exist in OpenAI's API — the available model is `gpt-5.4` (base)
- Adds 5.4 variants (high/xhigh/medium) using the correct model ID
- Keeps 5.3-codex variants as fallback, moves `recommended: true` to 5.4-high

## Test plan
- [ ] Verify `codex-5.4-high` dispatches correctly with `gpt-5.4` model ID
- [ ] Verify existing `codex-5.3-*` variants still work