### PR TITLE
feat: add Kiro CLI adapter with --trust-tools read-only enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.kiro/
 dist/
 release/
 agents/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Kiro CLI adapter (`kiro-cli`) — built-in support for Kiro CLI with model catalog (auto, Claude Opus/Sonnet/Haiku, DeepSeek, MiniMax, Qwen), stdin prompt delivery, and `--trust-tools` read-only enforcement
+
 ### Changed
 - Standalone release binaries are now built into `release/` instead of `dist/`, decoupling binary artifacts from npm package contents
 - Homebrew formula updates now target platform-specific GitHub release binaries directly (macOS/Linux, arm64/x64) instead of the npm tarball

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ By [Aaron Francis](https://aaronfrancis.com), creator of [Faster.dev](https://fa
 
 Fan out prompts to multiple AI coding agents in parallel.
 
-`counselors` dispatches the same prompt to Claude, Codex, Gemini, Amp, or custom tools simultaneously, collects their responses, and writes everything to a structured output directory.
+`counselors` dispatches the same prompt to Claude, Codex, Gemini, Amp, Kiro CLI, or custom tools simultaneously, collects their responses, and writes everything to a structured output directory.
 
 No MCP servers, no direct API integrations, no complex configuration. It just calls your locally installed CLI tools.
 
@@ -91,6 +91,7 @@ counselors run -t claude,codex "Review src/api/ for security issues and missing 
 | OpenAI Codex | `codex` | enforced | [github](https://github.com/openai/codex) |
 | Gemini CLI | `gemini` | enforced | [github](https://github.com/google-gemini/gemini-cli) |
 | Amp CLI | `amp` | enforced | [ampcode.com](https://ampcode.com) |
+| Kiro CLI | `kiro-cli` | enforced | [kiro.dev](https://kiro.dev/cli/) |
 | Custom | user-defined | configurable | — |
 
 ## Commands

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@biomejs/biome": "2.3.14",
         "@types/cross-spawn": "^6.0.6",
         "@types/node": "^22.0.0",
+        "fast-check": "^4.6.0",
         "tsup": "^8.0.0",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
@@ -1400,7 +1401,7 @@
       "version": "22.19.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.10.tgz",
       "integrity": "sha512-tF5VOugLS/EuDlTBijk0MqABfP8UxgYazTLo3uIn3b4yJgg26QRbVYJYsDtHrjdDUIRfP70+VfhTTc+CE1yskw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1860,6 +1861,29 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
+      "integrity": "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
       }
     },
     "node_modules/fdir": {
@@ -2341,6 +2365,23 @@
         }
       }
     },
+    "node_modules/pure-rand": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.3.0.tgz",
+      "integrity": "sha512-1ws1Ab8fnsf4bvpL+SujgBnr3KFs5abgCLVzavBp+f2n8Ld5YTOZlkv/ccYPhu3X9s+MEeqPRMqKlJz/kWDK8A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -2775,7 +2816,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@biomejs/biome": "2.3.14",
     "@types/cross-spawn": "^6.0.6",
     "@types/node": "^22.0.0",
+    "fast-check": "^4.6.0",
     "tsup": "^8.0.0",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -4,12 +4,14 @@ import { ClaudeAdapter } from './claude.js';
 import { CodexAdapter } from './codex.js';
 import { CustomAdapter } from './custom.js';
 import { GeminiAdapter } from './gemini.js';
+import { KiroCliAdapter } from './kiro-cli.js';
 
 const builtInAdapters: Record<string, () => ToolAdapter> = {
   claude: () => new ClaudeAdapter(),
   codex: () => new CodexAdapter(),
   gemini: () => new GeminiAdapter(),
   amp: () => new AmpAdapter(),
+  'kiro-cli': () => new KiroCliAdapter(),
 };
 
 export function getAdapter(id: string, config?: ToolConfig): ToolAdapter {

--- a/src/adapters/kiro-cli.ts
+++ b/src/adapters/kiro-cli.ts
@@ -1,0 +1,115 @@
+import { countWords } from '../core/text-utils.js';
+import type {
+  ExecResult,
+  Invocation,
+  RunRequest,
+  ToolReport,
+} from '../types.js';
+import { BaseAdapter } from './base.js';
+
+export class KiroCliAdapter extends BaseAdapter {
+  id = 'kiro-cli';
+  displayName = 'Kiro CLI';
+  commands = ['kiro-cli'];
+  installUrl = 'https://kiro.dev/cli/';
+  readOnly = { level: 'enforced' as const };
+  modelFlag = '--model';
+  models = [
+    {
+      id: 'auto',
+      name: 'Auto — task-optimized model routing (recommended)',
+      recommended: true,
+      extraFlags: ['--model', 'auto'],
+    },
+    {
+      id: 'claude-opus-4.6',
+      name: 'Claude Opus 4.6 — most capable',
+      extraFlags: ['--model', 'claude-opus-4.6'],
+    },
+    {
+      id: 'claude-sonnet-4.6',
+      name: 'Claude Sonnet 4.6 — balanced',
+      extraFlags: ['--model', 'claude-sonnet-4.6'],
+    },
+    {
+      id: 'claude-opus-4.5',
+      name: 'Claude Opus 4.5',
+      extraFlags: ['--model', 'claude-opus-4.5'],
+    },
+    {
+      id: 'claude-sonnet-4.5',
+      name: 'Claude Sonnet 4.5',
+      extraFlags: ['--model', 'claude-sonnet-4.5'],
+    },
+    {
+      id: 'claude-sonnet-4',
+      name: 'Claude Sonnet 4 — regular use',
+      extraFlags: ['--model', 'claude-sonnet-4'],
+    },
+    {
+      id: 'claude-haiku-4.5',
+      name: 'Claude Haiku 4.5 — fast, lightweight',
+      extraFlags: ['--model', 'claude-haiku-4.5'],
+    },
+    {
+      id: 'deepseek-3.2',
+      name: 'DeepSeek V3.2 — experimental',
+      extraFlags: ['--model', 'deepseek-3.2'],
+    },
+    {
+      id: 'minimax-m2.5',
+      name: 'MiniMax M2.5 — experimental',
+      extraFlags: ['--model', 'minimax-m2.5'],
+    },
+    {
+      id: 'minimax-m2.1',
+      name: 'MiniMax M2.1 — experimental',
+      extraFlags: ['--model', 'minimax-m2.1'],
+    },
+    {
+      id: 'qwen3-coder-next',
+      name: 'Qwen3 Coder Next — experimental',
+      extraFlags: ['--model', 'qwen3-coder-next'],
+    },
+  ];
+
+  buildInvocation(req: RunRequest): Invocation {
+    const args = ['chat', '--no-interactive', '--wrap', 'never'];
+
+    if (req.extraFlags) {
+      args.push(...req.extraFlags);
+    }
+
+    if (req.readOnlyPolicy !== 'none') {
+      args.push(
+        '--trust-tools',
+        [
+          'fs_read',
+          'fs_list',
+          'fs_search',
+          'web_search',
+          'web_fetch',
+        ].join(','),
+      );
+    }
+
+    return {
+      cmd: req.binary ?? 'kiro-cli',
+      args,
+      stdin: req.prompt,
+      cwd: req.cwd,
+    };
+  }
+
+  parseResult(result: ExecResult): Partial<ToolReport> {
+    const base = super.parseResult(result);
+    let { stdout } = result;
+
+    if (stdout.startsWith('> ')) {
+      stdout = stdout.slice(2);
+      base.wordCount = countWords(stdout);
+    }
+
+    return base;
+  }
+}

--- a/tests/unit/adapters/kiro-cli.test.ts
+++ b/tests/unit/adapters/kiro-cli.test.ts
@@ -1,0 +1,357 @@
+import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { KiroCliAdapter } from '../../../src/adapters/kiro-cli.js';
+import type { ExecResult, RunRequest } from '../../../src/types.js';
+
+describe('KiroCliAdapter', () => {
+  const adapter = new KiroCliAdapter();
+
+  const baseRequest: RunRequest = {
+    prompt: 'test prompt',
+    promptFilePath: '/tmp/prompt.md',
+    toolId: 'kiro-cli',
+    outputDir: '/tmp/out',
+    readOnlyPolicy: 'enforced',
+    timeout: 540,
+    cwd: '/tmp',
+    extraFlags: ['--model', 'auto'],
+  };
+
+  // ── Metadata tests (Requirement 7.1) ──
+
+  it('has correct metadata', () => {
+    expect(adapter.id).toBe('kiro-cli');
+    expect(adapter.displayName).toBe('Kiro CLI');
+    expect(adapter.commands).toEqual(['kiro-cli']);
+    expect(adapter.installUrl).toBe('https://kiro.dev/cli/');
+    expect(adapter.readOnly.level).toBe('enforced');
+    expect(adapter.modelFlag).toBe('--model');
+    expect(adapter.models).toHaveLength(11);
+    expect(adapter.models[0]).toEqual({
+      id: 'auto',
+      name: 'Auto — task-optimized model routing (recommended)',
+      recommended: true,
+      extraFlags: ['--model', 'auto'],
+    });
+  });
+
+  // ── Model catalog validation tests (Requirements 3.2, 3.3, 3.4) ──
+
+  it('every model entry has non-empty id, name, and correct extraFlags', () => {
+    for (const model of adapter.models) {
+      expect(model.id).toBeTruthy();
+      expect(model.name).toBeTruthy();
+      expect(model.extraFlags).toEqual(['--model', model.id]);
+    }
+  });
+
+  it('exactly one model has recommended: true and its id is auto', () => {
+    const recommended = adapter.models.filter((m) => m.recommended === true);
+    expect(recommended).toHaveLength(1);
+    expect(recommended[0].id).toBe('auto');
+  });
+
+  it('buildInvocation passes model extraFlags through to args', () => {
+    const req: RunRequest = {
+      prompt: 'test',
+      promptFilePath: '/tmp/prompt.md',
+      toolId: 'kiro-cli',
+      outputDir: '/tmp/out',
+      readOnlyPolicy: 'enforced',
+      timeout: 540,
+      cwd: '/tmp',
+      extraFlags: ['--model', 'claude-opus-4.6'],
+    };
+    const inv = adapter.buildInvocation(req);
+    expect(inv.args).toContain('--model');
+    expect(inv.args).toContain('claude-opus-4.6');
+  });
+
+  // ── buildInvocation tests (Requirements 7.2, 7.8) ──
+
+  it('builds invocation with base args and stdin prompt', () => {
+    const inv = adapter.buildInvocation(baseRequest);
+    expect(inv.args).toContain('chat');
+    expect(inv.args).toContain('--no-interactive');
+    expect(inv.args).toContain('--wrap');
+    expect(inv.args).toContain('never');
+    expect(inv.stdin).toBe('test prompt');
+    expect(inv.cwd).toBe('/tmp');
+  });
+
+  it('includes --trust-tools with read-only tool list when readOnlyPolicy is not none', () => {
+    for (const policy of ['enforced', 'bestEffort'] as const) {
+      const req = { ...baseRequest, readOnlyPolicy: policy };
+      const inv = adapter.buildInvocation(req);
+      const idx = inv.args.indexOf('--trust-tools');
+      expect(idx).toBeGreaterThan(-1);
+      expect(inv.args[idx + 1]).toBe(
+        'fs_read,fs_list,fs_search,web_search,web_fetch',
+      );
+    }
+  });
+
+  it('does not include --trust-tools when readOnlyPolicy is none', () => {
+    const req = { ...baseRequest, readOnlyPolicy: 'none' as const };
+    const inv = adapter.buildInvocation(req);
+    expect(inv.args).not.toContain('--trust-tools');
+  });
+
+  it('uses req.binary when provided', () => {
+    const req = { ...baseRequest, binary: '/custom/path/kiro-cli' };
+    const inv = adapter.buildInvocation(req);
+    expect(inv.cmd).toBe('/custom/path/kiro-cli');
+  });
+
+  it('falls back to "kiro-cli" when req.binary is undefined', () => {
+    const inv = adapter.buildInvocation(baseRequest);
+    expect(inv.cmd).toBe('kiro-cli');
+  });
+
+  it('includes extra flags from req.extraFlags', () => {
+    const inv = adapter.buildInvocation(baseRequest);
+    expect(inv.args).toContain('--model');
+    expect(inv.args).toContain('auto');
+  });
+
+  it('handles undefined extraFlags without crashing', () => {
+    const req = { ...baseRequest, extraFlags: undefined };
+    const inv = adapter.buildInvocation(req);
+    expect(inv.args).toContain('chat');
+    expect(inv.args).toContain('--no-interactive');
+  });
+
+  // ── parseResult tests (Requirements 7.6, 7.7) ──
+
+  it('strips "> " prefix from first line of stdout', () => {
+    const result: ExecResult = {
+      exitCode: 0,
+      stdout: '> Hello world output',
+      stderr: '',
+      timedOut: false,
+      durationMs: 1000,
+    };
+    const parsed = adapter.parseResult(result);
+    expect(parsed.wordCount).toBe(3); // "Hello world output"
+  });
+
+  it('passes through stdout without "> " prefix unchanged', () => {
+    const result: ExecResult = {
+      exitCode: 0,
+      stdout: 'Hello world output',
+      stderr: '',
+      timedOut: false,
+      durationMs: 1000,
+    };
+    const parsed = adapter.parseResult(result);
+    expect(parsed.wordCount).toBe(3); // "Hello world output"
+  });
+
+  it('preserves status, exitCode, durationMs from base', () => {
+    const result: ExecResult = {
+      exitCode: 1,
+      stdout: '> error output',
+      stderr: 'some error',
+      timedOut: false,
+      durationMs: 2500,
+    };
+    const parsed = adapter.parseResult(result);
+    expect(parsed.status).toBe('error');
+    expect(parsed.exitCode).toBe(1);
+    expect(parsed.durationMs).toBe(2500);
+  });
+
+  it('reports timeout status when timedOut is true', () => {
+    const result: ExecResult = {
+      exitCode: 1,
+      stdout: '',
+      stderr: '',
+      timedOut: true,
+      durationMs: 540000,
+    };
+    const parsed = adapter.parseResult(result);
+    expect(parsed.status).toBe('timeout');
+  });
+
+  // ── Property-Based Tests ──
+
+  // Shared arbitrary RunRequest generator
+  const arbReadOnlyPolicy = fc.constantFrom(
+    'enforced' as const,
+    'bestEffort' as const,
+    'none' as const,
+  );
+
+  const arbFlag = fc
+    .string({ minLength: 1, maxLength: 20 })
+    .filter((s) => s.trim().length > 0);
+
+  const arbExtraFlags = fc.oneof(
+    fc.constant(undefined),
+    fc.array(arbFlag, { minLength: 0, maxLength: 5 }),
+  );
+
+  const arbRunRequest = (): fc.Arbitrary<RunRequest> =>
+    fc
+      .record({
+        prompt: fc.string({ minLength: 0, maxLength: 200 }),
+        readOnlyPolicy: arbReadOnlyPolicy,
+        extraFlags: arbExtraFlags,
+        binary: fc.oneof(
+          fc.constant(undefined),
+          fc
+            .string({ minLength: 1, maxLength: 30 })
+            .filter((s) => s.trim().length > 0),
+        ),
+      })
+      .map((r) => ({
+        prompt: r.prompt,
+        promptFilePath: '/tmp/prompt.md',
+        toolId: 'kiro-cli',
+        outputDir: '/tmp/out',
+        readOnlyPolicy: r.readOnlyPolicy,
+        timeout: 540,
+        cwd: '/tmp',
+        binary: r.binary,
+        extraFlags: r.extraFlags,
+      }));
+
+  // Feature: kiro-cli-adapter, Property 1: Base args invariant
+  it('property: base args are always present', () => {
+    fc.assert(
+      fc.property(arbRunRequest(), (req) => {
+        const inv = adapter.buildInvocation(req);
+        expect(inv.args).toContain('chat');
+        expect(inv.args).toContain('--no-interactive');
+        expect(inv.args).toContain('--wrap');
+        expect(inv.args).toContain('never');
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  // Feature: kiro-cli-adapter, Property 2: Stdin prompt delivery
+  it('property: stdin always contains the prompt', () => {
+    fc.assert(
+      fc.property(arbRunRequest(), (req) => {
+        const inv = adapter.buildInvocation(req);
+        expect(inv.stdin).toBe(req.prompt);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  // Feature: kiro-cli-adapter, Property 3: No positional prompt in args
+  it('property: args never contain the prompt text or file-read instruction', () => {
+    fc.assert(
+      fc.property(
+        arbRunRequest().filter((r) => r.prompt.length > 0),
+        (req) => {
+          const inv = adapter.buildInvocation(req);
+          expect(inv.args).not.toContain(req.prompt);
+          expect(inv.args.join(' ')).not.toContain('Read the file');
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  // Feature: kiro-cli-adapter, Property 4: Trust tools enforcement based on readOnlyPolicy
+  it('property: --trust-tools present when readOnlyPolicy is not none, absent when none', () => {
+    fc.assert(
+      fc.property(arbRunRequest(), (req) => {
+        const inv = adapter.buildInvocation(req);
+        expect(inv.args).not.toContain('--trust-all-tools');
+        const idx = inv.args.indexOf('--trust-tools');
+        if (req.readOnlyPolicy !== 'none') {
+          expect(idx).toBeGreaterThan(-1);
+          expect(inv.args[idx + 1]).toBe(
+            'fs_read,fs_list,fs_search,web_search,web_fetch',
+          );
+        } else {
+          expect(idx).toBe(-1);
+        }
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  // Feature: kiro-cli-adapter, Property 6: Extra flags inclusion
+  it('property: every extra flag appears in args', () => {
+    fc.assert(
+      fc.property(
+        arbRunRequest().filter(
+          (r) => r.extraFlags !== undefined && r.extraFlags.length > 0,
+        ),
+        (req) => {
+          const inv = adapter.buildInvocation(req);
+          for (const flag of req.extraFlags!) {
+            expect(inv.args).toContain(flag);
+          }
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  // Feature: kiro-cli-adapter, Property 7: Binary fallback
+  it('property: cmd equals req.binary when provided, kiro-cli otherwise', () => {
+    fc.assert(
+      fc.property(arbRunRequest(), (req) => {
+        const inv = adapter.buildInvocation(req);
+        if (req.binary !== undefined) {
+          expect(inv.cmd).toBe(req.binary);
+        } else {
+          expect(inv.cmd).toBe('kiro-cli');
+        }
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  // Feature: kiro-cli-adapter, Property 8: parseResult prefix stripping and field preservation
+  it('property: parseResult preserves base fields and strips "> " prefix correctly', () => {
+    const arbExecResult = fc
+      .record({
+        exitCode: fc.oneof(fc.constant(0), fc.constant(1)),
+        stdout: fc.oneof(
+          fc.string({ minLength: 0, maxLength: 200 }),
+          fc.string({ minLength: 0, maxLength: 200 }).map((s) => `> ${s}`),
+        ),
+        stderr: fc.string({ minLength: 0, maxLength: 50 }),
+        timedOut: fc.boolean(),
+        durationMs: fc.nat({ max: 600000 }),
+      })
+      .map((r) => r as ExecResult);
+
+    fc.assert(
+      fc.property(arbExecResult, (result) => {
+        const parsed = adapter.parseResult(result);
+
+        // Field preservation
+        expect(parsed.exitCode).toBe(result.exitCode);
+        expect(parsed.durationMs).toBe(result.durationMs);
+        expect(parsed.status).toBe(
+          result.timedOut
+            ? 'timeout'
+            : result.exitCode === 0
+              ? 'success'
+              : 'error',
+        );
+
+        // Prefix stripping
+        if (result.stdout.startsWith('> ')) {
+          const stripped = result.stdout.slice(2);
+          const expectedWords = stripped.split(/\s+/).filter(Boolean).length;
+          expect(parsed.wordCount).toBe(expectedWords);
+        } else {
+          const expectedWords = result.stdout
+            .split(/\s+/)
+            .filter(Boolean).length;
+          expect(parsed.wordCount).toBe(expectedWords);
+        }
+      }),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/tests/unit/adapters/resolve.test.ts
+++ b/tests/unit/adapters/resolve.test.ts
@@ -36,6 +36,16 @@ describe('resolveAdapter', () => {
     expect(adapter.id).toBe('gemini');
   });
 
+  it('resolves compound kiro-cli ID to KiroCliAdapter', () => {
+    const config: ToolConfig = {
+      binary: '/usr/local/bin/kiro-cli',
+      adapter: 'kiro-cli',
+      readOnly: { level: 'enforced' },
+    };
+    const adapter = resolveAdapter('kiro-cli-claude-opus-4.6', config);
+    expect(adapter.id).toBe('kiro-cli');
+  });
+
   it('resolves plain built-in ID without adapter field', () => {
     const config: ToolConfig = {
       binary: '/usr/local/bin/claude',


### PR DESCRIPTION
# Add Kiro CLI adapter

Adds a new adapter for [Kiro CLI](https://kiro.dev/cli/) as a supported counselor tool.

## What's included

- `KiroCliAdapter` implementing `buildInvocation()` with stdin-based prompt delivery and `--no-interactive --wrap never` base args
- Model catalog: auto (recommended), Claude Opus/Sonnet/Haiku 4.x, DeepSeek 3.2, MiniMax M2.x, Qwen3 Coder Next
- Read-only enforcement via `--trust-tools=fs_read,fs_list,fs_search,web_search,web_fetch` when `readOnlyPolicy` is `enforced` or `bestEffort`, consistent with how Claude, Codex, and Gemini adapters whitelist tools at invocation time
- `parseResult()` override to strip the `> ` prefix from kiro-cli's stdout format
- Adapter registered in `adapters/index.ts`
- Full unit tests including property-based tests (fast-check) covering base args, stdin delivery, trust-tools enforcement, binary fallback, extra flags passthrough, and parseResult behavior

## Design decisions

- Uses `--trust-tools` with an explicit read-only tool list rather than `--trust-all-tools`, matching the least-privilege approach of the other adapters
- Prompt delivered via stdin (like Amp and Gemini) rather than positional arg (like Claude and Codex)
- No `--trust-tools` flag when `readOnlyPolicy` is `none`, allowing full tool access in that mode