### PR TITLE
feat: add Claude Fable 5 model presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New Claude Fable 5 model presets (`claude-fable-high`, `claude-fable`), now the recommended default ahead of the existing Opus/Sonnet/Haiku presets
+
 ### Changed
 - Standalone release binaries are now built into `release/` instead of `dist/`, decoupling binary artifacts from npm package contents
 - Homebrew formula updates now target platform-specific GitHub release binaries directly (macOS/Linux, arm64/x64) instead of the npm tarball

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -11,9 +11,21 @@ export class ClaudeAdapter extends BaseAdapter {
   modelFlag = '--model';
   models = [
     {
+      id: 'fable',
+      compoundId: 'claude-fable-high',
+      name: 'Fable 5 — most capable, high effort',
+      recommended: true,
+      extraFlags: ['--model', 'fable', '--effort', 'high'],
+    },
+    {
+      id: 'fable',
+      compoundId: 'claude-fable',
+      name: 'Fable 5 — most capable, default effort',
+      extraFlags: ['--model', 'fable'],
+    },
+    {
       id: 'opus',
       name: 'Opus 4.6 — most capable',
-      recommended: true,
       extraFlags: ['--model', 'opus'],
     },
     {

--- a/tests/unit/adapters/claude.test.ts
+++ b/tests/unit/adapters/claude.test.ts
@@ -23,6 +23,47 @@ describe('ClaudeAdapter', () => {
     expect(adapter.modelFlag).toBe('--model');
   });
 
+  it('offers Fable 5 presets ahead of Opus/Sonnet/Haiku', () => {
+    expect(adapter.models.map((m) => m.id)).toEqual([
+      'fable',
+      'fable',
+      'opus',
+      'sonnet',
+      'haiku',
+    ]);
+    expect(adapter.models[0].compoundId).toBe('claude-fable-high');
+    expect(adapter.models[0].extraFlags).toEqual([
+      '--model',
+      'fable',
+      '--effort',
+      'high',
+    ]);
+    expect(adapter.models[1].compoundId).toBe('claude-fable');
+    expect(adapter.models[1].extraFlags).toEqual(['--model', 'fable']);
+  });
+
+  it('only marks the high-effort Fable model as recommended', () => {
+    expect(adapter.models[0].recommended).toBe(true);
+    for (const model of adapter.models.slice(1)) {
+      expect(model.recommended).toBeFalsy();
+    }
+  });
+
+  it('passes Fable effort flags through before the instruction', () => {
+    const req = {
+      ...baseRequest,
+      extraFlags: ['--model', 'fable', '--effort', 'high'],
+    };
+    const inv = adapter.buildInvocation(req);
+    const effortIdx = inv.args.indexOf('--effort');
+    const instructionIdx = inv.args.findIndex((a) =>
+      a.startsWith('Read the file'),
+    );
+    expect(effortIdx).toBeGreaterThan(-1);
+    expect(inv.args[effortIdx + 1]).toBe('high');
+    expect(effortIdx).toBeLessThan(instructionIdx);
+  });
+
   it('builds invocation with read-only flags', () => {
     const inv = adapter.buildInvocation(baseRequest);
     expect(inv.cmd).toBe('claude');


### PR DESCRIPTION
## Summary

Anthropic shipped Fable 5, its most capable model (positioned above Opus).

- Adds two presets — `claude-fable-high` (`--model fable --effort high`, recommended) and `claude-fable` (default effort) — ahead of the existing Opus/Sonnet/Haiku entries
- Opus/Sonnet/Haiku are left completely untouched; `recommended: true` simply moves from Opus to Fable-high, so anyone pinning a specific tier sees no change

Note: `counselors init --auto` configures every preset in an adapter's model list (not just the recommended one), and a bare `counselors run` dispatches all configured tools — so this does grow that default fan-out by 2 entries for new installs. Flagging that explicitly rather than leaving it implicit.

## Test plan

- [x] `npm run typecheck && npm run lint && npm run build && npm test` all pass
- [x] Verified against the installed Claude Code CLI: `--effort` accepts `low|medium|high|xhigh|max`, and the composed invocation (`-p --output-format text --model fable --effort high` + the existing read-only tool set) completes successfully end to end

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>