### PR TITLE
feat: add GPT-5.6 Sol/Terra/Luna presets to the Codex adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New GPT-5.6 Codex model presets (`codex-sol-high`/`-xhigh`/`-medium`, `codex-terra`, `codex-luna`), with Sol-high now the recommended default ahead of the existing gpt-5.3-codex presets
+
 ### Changed
 - Standalone release binaries are now built into `release/` instead of `dist/`, decoupling binary artifacts from npm package contents
 - Homebrew formula updates now target platform-specific GitHub release binaries directly (macOS/Linux, arm64/x64) instead of the npm tarball

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -10,10 +10,40 @@ export class CodexAdapter extends BaseAdapter {
   readOnly = { level: 'enforced' as const };
   models = [
     {
+      id: 'gpt-5.6-sol',
+      compoundId: 'codex-sol-high',
+      name: 'GPT-5.6 Sol — flagship, high reasoning',
+      recommended: true,
+      extraFlags: ['-m', 'gpt-5.6-sol', '-c', 'model_reasoning_effort=high'],
+    },
+    {
+      id: 'gpt-5.6-sol',
+      compoundId: 'codex-sol-xhigh',
+      name: 'GPT-5.6 Sol — flagship, xhigh reasoning',
+      extraFlags: ['-m', 'gpt-5.6-sol', '-c', 'model_reasoning_effort=xhigh'],
+    },
+    {
+      id: 'gpt-5.6-sol',
+      compoundId: 'codex-sol-medium',
+      name: 'GPT-5.6 Sol — flagship, medium reasoning',
+      extraFlags: ['-m', 'gpt-5.6-sol', '-c', 'model_reasoning_effort=medium'],
+    },
+    {
+      id: 'gpt-5.6-terra',
+      compoundId: 'codex-terra',
+      name: 'GPT-5.6 Terra — balanced, everyday work',
+      extraFlags: ['-m', 'gpt-5.6-terra'],
+    },
+    {
+      id: 'gpt-5.6-luna',
+      compoundId: 'codex-luna',
+      name: 'GPT-5.6 Luna — fastest, most affordable',
+      extraFlags: ['-m', 'gpt-5.6-luna'],
+    },
+    {
       id: 'gpt-5.3-codex',
       compoundId: 'codex-5.3-high',
       name: 'GPT-5.3 Codex — high reasoning',
-      recommended: true,
       extraFlags: ['-m', 'gpt-5.3-codex', '-c', 'model_reasoning_effort=high'],
     },
     {

--- a/tests/unit/adapters/codex.test.ts
+++ b/tests/unit/adapters/codex.test.ts
@@ -88,31 +88,47 @@ describe('CodexAdapter', () => {
     expect(effortIdx).toBeLessThan(instructionIdx);
   });
 
-  it('has three gpt-5.3-codex models with different reasoning efforts', () => {
-    expect(adapter.models).toHaveLength(3);
-    expect(adapter.models.map((m) => m.compoundId)).toEqual([
+  it('has three gpt-5.6-sol models with different reasoning efforts', () => {
+    const sol = adapter.models.filter((m) => m.id === 'gpt-5.6-sol');
+    expect(sol).toHaveLength(3);
+    expect(sol.map((m) => m.compoundId)).toEqual([
+      'codex-sol-high',
+      'codex-sol-xhigh',
+      'codex-sol-medium',
+    ]);
+  });
+
+  it('also offers Terra and Luna as single-tier presets', () => {
+    const terra = adapter.models.find((m) => m.id === 'gpt-5.6-terra');
+    const luna = adapter.models.find((m) => m.id === 'gpt-5.6-luna');
+    expect(terra?.compoundId).toBe('codex-terra');
+    expect(terra?.extraFlags).toEqual(['-m', 'gpt-5.6-terra']);
+    expect(luna?.compoundId).toBe('codex-luna');
+    expect(luna?.extraFlags).toEqual(['-m', 'gpt-5.6-luna']);
+  });
+
+  it('still has three gpt-5.3-codex models with different reasoning efforts', () => {
+    const legacy = adapter.models.filter((m) => m.id === 'gpt-5.3-codex');
+    expect(legacy).toHaveLength(3);
+    expect(legacy.map((m) => m.compoundId)).toEqual([
       'codex-5.3-high',
       'codex-5.3-xhigh',
       'codex-5.3-medium',
     ]);
-    expect(adapter.models.every((m) => m.id === 'gpt-5.3-codex')).toBe(true);
   });
 
-  it('only marks the first model as recommended', () => {
+  it('only marks Sol high-reasoning as recommended', () => {
+    expect(adapter.models[0].compoundId).toBe('codex-sol-high');
     expect(adapter.models[0].recommended).toBe(true);
-    expect(adapter.models[1].recommended).toBeFalsy();
-    expect(adapter.models[2].recommended).toBeFalsy();
+    for (const model of adapter.models.slice(1)) {
+      expect(model.recommended).toBeFalsy();
+    }
   });
 
-  it('each model has correct extraFlags for its reasoning effort', () => {
-    expect(adapter.models[0].extraFlags).toContain(
-      'model_reasoning_effort=high',
-    );
-    expect(adapter.models[1].extraFlags).toContain(
-      'model_reasoning_effort=xhigh',
-    );
-    expect(adapter.models[2].extraFlags).toContain(
-      'model_reasoning_effort=medium',
-    );
+  it('each Sol model has correct extraFlags for its reasoning effort', () => {
+    const sol = adapter.models.filter((m) => m.id === 'gpt-5.6-sol');
+    expect(sol[0].extraFlags).toContain('model_reasoning_effort=high');
+    expect(sol[1].extraFlags).toContain('model_reasoning_effort=xhigh');
+    expect(sol[2].extraFlags).toContain('model_reasoning_effort=medium');
   });
 });


### PR DESCRIPTION
## Summary

OpenAI shipped GPT-5.6, a three-tier family (Sol/Terra/Luna, Sun/Earth/Moon) that replaces the old versioned `gpt-5.x-codex` naming — no more `-codex` suffix.

- Adds Sol as the new flagship (3 reasoning-effort presets: high/recommended, xhigh, medium — mirroring the existing `gpt-5.3-codex` shape) plus single-tier Terra and Luna presets, ahead of the existing `gpt-5.3-codex` trio
- The `gpt-5.3-codex` trio is left completely untouched as a fallback for anyone pinning that generation; `recommended: true` simply moves from `codex-5.3-high` to `codex-sol-high`

Aware of #34 (GPT-5.4 as an intermediate generation) — this targets 5.6, which supersedes both 5.3 and 5.4. Happy to defer or rebase depending on how you'd like to sequence these.

Note: `counselors init --auto` configures every preset in an adapter's model list (not just the recommended one), and a bare `counselors run` dispatches all configured tools — so this does grow that default fan-out by 5 entries for new installs (upstream's own existing 3-entry `gpt-5.3-codex` trio already does this today, for reference).

## Test plan

- [x] `npm run typecheck && npm run lint && npm run build && npm test` all pass
- [x] Model IDs (`gpt-5.6-sol`/`terra`/`luna`) verified live against `codex-cli`: recognized directly (no "model metadata not found" fallback warning, unlike guessed/nonexistent slugs), and the exact composed invocation completes successfully for all three

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>